### PR TITLE
fix: split geoloc of shops into two fields and update payloads & readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ Status: 200 OK
       "siret": "12345678901234",
       "email": "bistrot123@gmail.com",
       "zipCode": "12345",
-      "geoloc": "22.366329,-10.137468",
+      "lat":"22.366329",
+      "long": "-10.137468",
       "phone": "0632547698",
       "address": "12 rue du bistrot",
     },
@@ -172,7 +173,8 @@ Status: 200 OK
       "siret": "98765432101234",
       "email": "coffeeshop@gmail.com",
       "zipCode": "54321",
-      "geoloc": "18.365229,-11.147119",
+      "lat": "18.365229",
+      "long": "-11.147119",
       "phone": "0698765432",
       "address": "1 rue du café",
     },
@@ -301,7 +303,8 @@ Status: 200 OK
     "siret": "12345678901234",
     "email": "bistrot123@gmail.com",
     "zipCode": "12345",
-    "geoloc": "22.366329,-10.137468",
+    "lat":"22.366329",
+    "long": "-10.137468",
     "phone": "0632547698",
     "address": "12 rue du bistrot",
   }
@@ -333,7 +336,8 @@ Status: 200 OK
   "siret": "12345678901234",
   "email": "bistrot123@gmail.com",
   "zipCode": "12345",
-  "geoloc": "22.366329,-10.137468",
+  "lat":"22.366329",
+  "long": "-10.137468",
   "phone": "0632547698",
   "address": "12 rue du bistrot",
 }
@@ -382,7 +386,8 @@ POST /shops
 | **siret**       | string | body | **[required]** |
 | **email**       | string | body | **[required]** |
 | **zipCode**     | string | body | **[required]** |
-| **geoloc**      | string | body | **[required]** |
+| **lat**      | string | body | **[required]** |
+| **long**      | string | body | **[required]** |
 | **phone**       | string | body | **[required]** |
 | **address**     | string | body | **[required]** |
 
@@ -395,7 +400,8 @@ POST /shops
     "siret": "12345678901234",
     "email": "bistrot123@gmail.com",
     "zipCode": "12345",
-    "geoloc": "22.366329,-10.137468",
+    "lat":"22.366329",
+    "long": "-10.137468",
     "phone": "0632547698",
     "address": "12 rue du bistrot",
   }
@@ -423,7 +429,8 @@ PUT /shops/:id
 | **siret**       | string | body  | **[optional]** |
 | **email**       | string | body  | **[optional]** |
 | **zipCode**     | string | body  | **[optional]** |
-| **geoloc**      | string | body  | **[optional]** |
+| **lat**      | string | body  | **[optional]** |
+| **long**      | string | body  | **[optional]** |
 | **phone**       | string | body  | **[optional]** |
 | **address**     | string | body  | **[optional]** |
 
@@ -436,7 +443,8 @@ PUT /shops/1
     "siret": "12345678901234",
     "email": "bistrot123@gmail.com",
     "zipCode": "12345",
-    "geoloc": "22.366329,-10.137468",
+    "lat":"22.366329",
+    "long": "-10.137468",
     "phone": "0632547698",
     "address": "12 rue du bistrot",
   }

--- a/src/entities/shop.ts
+++ b/src/entities/shop.ts
@@ -2,7 +2,8 @@
 import {
   IsBoolean,
   IsEmail,
-  IsLatLong,
+  IsLatitude,
+  IsLongitude,
   IsNotEmpty,
   IsPhoneNumber,
   IsPostalCode,
@@ -55,9 +56,14 @@ export class Shop {
   zipCode: string;
 
   @IsNotEmpty()
-  @IsLatLong()
+  @IsLatitude()
   @Column()
-  geoloc: string;
+  lat: string;
+
+  @IsNotEmpty()
+  @IsLongitude()
+  @Column()
+  long: string;
 
   @IsNotEmpty()
   @IsPhoneNumber("FR")

--- a/src/payloads/shop.payload.ts
+++ b/src/payloads/shop.payload.ts
@@ -4,7 +4,8 @@ export interface IShopCreatePayload {
   siret: string;
   email: string;
   zipCode: string;
-  geoloc: string;
+  lat: string;
+  long: string;
   phone: string;
   address: string;
 }
@@ -15,7 +16,8 @@ export interface IShopUpdatePayload {
   siret?: string;
   email?: string;
   zipCode?: string;
-  geoloc?: number;
+  lat?: string;
+  long?: string;
   phone?: string;
   address?: string;
 }

--- a/src/tests/seeds/shop.seed.ts
+++ b/src/tests/seeds/shop.seed.ts
@@ -6,7 +6,8 @@ export const shopFixture: IShopCreatePayload = {
   siret: "12345678901234",
   email: "bistrot123@gmail.com",
   zipCode: "12345",
-  geoloc: "22.366329,-10.137468",
+  lat: "22.366329",
+  long: "-10.137468",
   phone: "0632547698",
   address: "12 rue du bistrot",
 };


### PR DESCRIPTION
### Changes proposed in this pull request
- Split geoloc field into two separate fields `lat` and `long`
- Update Readme

[FID-69]


[FID-69]: https://msc-etna.atlassian.net/browse/FID-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ